### PR TITLE
#7 - Support for running general queries

### DIFF
--- a/src/core/QueryBuilder.scala
+++ b/src/core/QueryBuilder.scala
@@ -1,0 +1,70 @@
+package mutatus
+
+import com.google.cloud.datastore, datastore._
+import com.google.cloud.datastore, datastore.StructuredQuery.Filter
+import language.experimental.macros
+
+case class QueryBuilder[T]private[mutatus](
+    kind: String,
+    filterCriteria: Option[Filter] = None,
+    orderCriteria: Map[String, StructuredQuery.OrderBy]=Map.empty,
+    offset: Option[Int] = None,
+    limit: Option[Int] = None ) {
+
+	import QueryBuilder._
+  sealed trait OrderBy {
+    def asc(path: T => Any): OrderBy
+    def desc(path: T => Any): OrderBy
+  }
+
+  // Following 2 methods would not be necessary in case if we could access private members of QueryBuilder inside macro evalulation
+  def withSortCriteria(orders: StructuredQuery.OrderBy*): QueryBuilder[T] = {
+    copy[T](orderCriteria = orders.foldLeft(orderCriteria) { case (acc, order) => acc.updated(order.getProperty, order) })
+  }
+
+  def withFilterCriteria(filters: StructuredQuery.Filter*): QueryBuilder[T] =
+    copy(filterCriteria = Option((filterCriteria ++ filters).toList.distinct)
+      .filter(_.nonEmpty)
+      .map {
+        case singleFilter :: Nil => singleFilter
+        case multiple => StructuredQuery.CompositeFilter.and(multiple.head, multiple.tail: _*)
+      }
+    )
+
+  def where(pred: T => Boolean): QueryBuilder[T] = macro QueryBuilderMacros.whereImpl[T]
+
+  def sortBy(pred: (T => Any)*)(implicit orderDirection: OrderDirection): QueryBuilder[T] = macro QueryBuilderMacros.sortByImpl[T]
+
+  def orderBy(pred: (OrderBy => Any)*): QueryBuilder[T] = macro QueryBuilderMacros.orderByImpl[T]
+
+  def limit(limit: Int, offset: Int): QueryBuilder[T] = {
+    this.copy(limit = Some(limit), offset = Some(offset))
+  }
+
+  /** Materializes query and returns Iterator of entities for GCP Storage */
+  def find()(implicit svc: Service, namespace: Namespace, decoder: Decoder[T]): Iterator[T] = {
+    val orderConditions = orderCriteria.values.toList
+
+    val baseQuery = namespace.option.foldLeft(Query.newEntityQueryBuilder().setKind(kind))(_.setNamespace(_))
+    val filtered = filterCriteria.foldLeft(baseQuery)(_.setFilter(_))
+    val ordered = orderConditions.headOption.foldLeft(filtered)(_.setOrderBy(_, orderConditions.tail: _*))
+    val limited = limit.foldLeft(ordered)(_.setLimit(_))
+    val withOffset = offset.foldLeft(limited)(_.setOffset(_))
+    val query = withOffset.build()
+
+    val results = svc.read.run(query)
+    new Iterator[Entity] {
+      def next(): Entity = results.next()
+
+      def hasNext: Boolean = results.hasNext
+    }.map(decoder.decode(_))
+  }
+}
+
+object QueryBuilder {
+  sealed trait OrderDirection
+  object OrderDirection {
+    case object Ascending extends OrderDirection
+    case object Descending extends OrderDirection
+  }
+}

--- a/src/core/QueryBuilder.scala
+++ b/src/core/QueryBuilder.scala
@@ -9,9 +9,8 @@ case class QueryBuilder[T]private[mutatus](
     filterCriteria: Option[Filter] = None,
     orderCriteria: Map[String, StructuredQuery.OrderBy]=Map.empty,
     offset: Option[Int] = None,
-    limit: Option[Int] = None ) {
-
-	import QueryBuilder._
+    limit: Option[Int] = None) {
+  import QueryBuilder._
   sealed trait OrderBy {
     def asc(path: T => Any): OrderBy
     def desc(path: T => Any): OrderBy
@@ -32,9 +31,7 @@ case class QueryBuilder[T]private[mutatus](
     )
 
   def where(pred: T => Boolean): QueryBuilder[T] = macro QueryBuilderMacros.whereImpl[T]
-
   def sortBy(pred: (T => Any)*)(implicit orderDirection: OrderDirection): QueryBuilder[T] = macro QueryBuilderMacros.sortByImpl[T]
-
   def orderBy(pred: (OrderBy => Any)*): QueryBuilder[T] = macro QueryBuilderMacros.orderByImpl[T]
 
   def limit(limit: Int, offset: Int): QueryBuilder[T] = {

--- a/src/core/QueryBuilderMacros.scala
+++ b/src/core/QueryBuilderMacros.scala
@@ -1,99 +1,143 @@
 package mutatus
 
+import scala.annotation.tailrec
 import scala.reflect.macros._
 
-object QueryBuilderMacros {
-  def whereImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Expr[T => Boolean]): c.universe.Tree = {
-    import c.universe._
-    val self = c.prefix
+class QueryBuilderMacros(val c: blackbox.Context) {
+  import c.universe._
+  private val self = c.prefix
+  private val selectLikeOperators = Set(
+    "isEmpty", "isDefined",
+    "last", "lastOption", "head", "headOption", "init", "tail", "get",
+    "toString")
+
+  def whereImpl[T: c.WeakTypeTag](pred: c.Expr[T => Boolean]): c.universe.Tree = {
+    val filter    = q"_root_.com.google.cloud.datastore.StructuredQuery.PropertyFilter"
+    val composite = q"_root_.com.google.cloud.datastore.StructuredQuery.CompositeFilter.and"
     val predicates = pred match {
       case Expr(q"(..$_) => $body") => body
     }
 
     @scala.annotation.tailrec
-    def resolveConditions(tree: c.Tree, resolved: List[c.Tree] = Nil): List[c.Tree] = {
+    def splitFilterCriteria(tree: c.Tree, resolved: List[c.Tree] = Nil): List[c.Tree] = {
       tree match {
         case q"$_ || $_" => c.abort(c.enclosingPosition, s"Google Query Language does not support OR operator: ${show(tree)}")
         case q"$head && $last" =>
-          resolveConditions(head.asInstanceOf[c.Tree], last :: resolved)
+          splitFilterCriteria(head.asInstanceOf[c.Tree], last :: resolved)
         case q"$head" => head :: resolved
       }
     }
 
-    val filter    = q"_root_.com.google.cloud.datastore.StructuredQuery.PropertyFilter"
-    val composite = q"_root_.com.google.cloud.datastore.StructuredQuery.CompositeFilter.and"
-    val queries: List[c.Tree] = resolveConditions(predicates.asInstanceOf[c.Tree])
-      .map {
-        case q"$_.${field}.${operator}[$_](..$args)" => (field, operator, args)
-        case q"$_.${field}.${operator}(..$args)" => (field, operator, args)
-        case q"$_.${field}.${operator}" => (field, operator, Nil)
-      }.map {
-      case (field, operator, args) =>
-        val fieldName = field match {
-          case TermName(fieldName) => Literal(Constant(fieldName))
-        }
+    def buildQueryCondition(condition: c.Tree): c.Tree = {
+      val DisassembledTree(path, operations) = disassembleSelectTree(condition)
+      val operationsMapping: PartialFunction[c.TermName, List[c.Tree] => c.Tree] = {
+        case TermName("$eq$eq")      => args => q"$filter.eq($path, ${args.head})"
+        case TermName("$less")       => args => q"$filter.lt($path, ${args.head})"
+        case TermName("$less$eq")    => args => q"$filter.le($path, ${args.head})"
+        case TermName("$greater")    => args => q"$filter.gt($path, ${args.head})"
+        case TermName("$greater$eq") => args => q"$filter.ge($path, ${args.head})"
+        case TermName("isEmpty")     => _    => q"$filter.isNull($path)"
 
-        operator match {
-          case TermName("$eq$eq") => q"$filter.eq($fieldName, ${args.head})"
-          case TermName("$less") => q"$filter.lt($fieldName, ${args.head})"
-          case TermName("$less$eq") => q"$filter.le($fieldName, ${args.head})"
-          case TermName("$greater") => q"$filter.gt($fieldName, ${args.head})"
-          case TermName("$greater$eq") => q"$filter.ge($fieldName, ${args.head})"
-          case TermName("isEmpty") => q"$filter.isNull($fieldName)"
-          case TermName("contains") => q"$filter.eq($fieldName, ${args.head})"
-          case other =>
-            c.abort(c.enclosingPosition, s"Not defined handling for operator $other and args $args")
-        }
+        case TermName("isDefined") | TermName("nonEmpty") =>
+          _ => q"$filter.gt($path, _root_.com.google.cloud.datastore.NullValue.of())"
+        case TermName("contains") | TermName("foreach") =>
+          args => q"$filter.eq($path, ${args.head})"
+      }
+
+      operations.collectFirst{
+        case (op, arg) if operationsMapping.isDefinedAt(op) =>
+          operationsMapping(op)(arg)
+      }.getOrElse(c.abort(c.enclosingPosition, s"Not found matching operation mapping for any of ${operations.map(_._1)}"))
     }
 
-    val query = if (queries.size > 1) {
-      q"$composite(..$queries)"
-    } else {
-      queries.head
+    val query = splitFilterCriteria(predicates)
+      .map(buildQueryCondition) match {
+      case Nil => c.abort(c.enclosingPosition, "Generated empty query, aborting")
+      case singleCondition :: Nil => singleCondition
+      case multipleConditions =>       q"$composite(..$multipleConditions)"
     }
     q"$self.withFilterCriteria($query)"
   }
 
-  def sortByImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Tree*)(orderDirection: c.Tree): c.universe.Tree = {
-    import c.universe._
-    val self = c.prefix
-    val sortBy: Seq[Literal] = pred.collect {
-      case q"(..$_) => $_.${field}" =>
-        field match {
-          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
-            fieldLiteral
-        }
-    }
+  def sortByImpl[T: c.WeakTypeTag](pred: c.Tree*)(orderDirection: c.Tree): c.universe.Tree = {
+    val sortBy: Seq[c.universe.Literal] = pred
+      .collect{
+        case q"(..$_) => $body" => disassembleSelectTree(body)
+      }
+      .map(_.pathLiteral)
 
-    q""" {
-         val isAscending = $orderDirection == _root_.mutatus.OrderDirection.Ascending
+    q"""{
+         val isAscending = $orderDirection == _root_.mutatus.QueryBuilder.OrderDirection.Ascending
          val sortBy: List[StructuredQuery.OrderBy] = if(isAscending){
             List(..$sortBy).map(_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc(_))
           }else{
             List(..$sortBy).map(_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc(_))
           }
-
-        $self.withSortCriteria(sortBy:_*)
+          $self.withSortCriteria(sortBy:_*)
         }
        """
   }
-  
-  def orderByImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Tree*): c.universe.Tree = {
-    import c.universe._
 
-    val self = c.prefix
-    val sortBy: Seq[c.Tree] = pred.collect {
-      case q"(..$_) => $_.asc((..$_) => $_.${field})" =>
-        field match {
-          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
-            q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc($fieldLiteral)"
-        }
-      case q"(..$_) => $_.desc((..$_) => $_.${field})" =>
-        field match {
-          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
-            q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc($fieldLiteral)"
-        }
+  def orderByImpl[T: c.WeakTypeTag](pred: c.Tree*): c.universe.Tree = {
+    val conditions = pred.collect {
+      case q"(..$_) => $_.asc((..$_) => $select)" =>   true -> disassembleSelectTree(select)
+      case q"(..$_) => $_.desc((..$_) => $select)" =>  false -> disassembleSelectTree(select)
+    }
+
+    val sortBy = conditions.map { case (isAscending, dt) =>
+      if (isAscending) {
+        q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc(${dt.pathLiteral})"
+      } else {
+        q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc(${dt.pathLiteral})"
+      }
     }
     q"$self.withSortCriteria(..$sortBy)"
+  }
+
+  type OpArgs = (c.TermName, List[c.Tree])
+  private case class DisassembledTree(path: String, operations: List[OpArgs]){
+    val pathLiteral: c.universe.Literal = Literal(Constant(path))
+  }
+
+  private def disassembleSelectTree(tree: c.Tree): DisassembledTree = {
+    @tailrec
+    def dissembleSelectTree(
+        tree: c.Tree,
+        selects: List[c.TermName] = Nil,
+        applies: List[OpArgs] = Nil): (String, List[OpArgs]) = {
+      def isSubpath(op: String): Boolean = {
+        selectLikeOperators.contains(op) || op.headOption.exists(_.isUpper)
+      }
+
+      tree match {
+        case q"$select.${operator}[$_](..$args)"         => dissembleSelectTree(select, selects, (operator, args) :: applies)
+        case q"$select.${operator}(..$args)"             => dissembleSelectTree(select, selects, (operator, args) :: applies)
+        case q"$select.${TermName(op)}" if isSubpath(op) => dissembleSelectTree(select, selects, (TermName(op), Nil) :: applies)
+        case q"$select.${operator}"                      => dissembleSelectTree(select, operator :: selects, applies)
+        case _                                           => selects.collect{case TermName(name) => name}.mkString(".") -> applies
+      }
+    }
+
+    @tailrec
+    def disassembleTree(
+          path: String,
+          tree: c.Tree,
+          nextOperations: List[OpArgs],
+          allOperations: List[OpArgs]): DisassembledTree = {
+      val (subPath, innerOperation) = dissembleSelectTree(tree)
+      val newPath = (path, subPath) match {
+        case (path, "") => path
+        case ("", subPath) => subPath
+        case (path, subPath) => s"$path.$subPath"
+      }
+      (innerOperation ++ nextOperations) match {
+        case (op, fn @ q"(..$_) => $body" :: Nil) :: next => disassembleTree(newPath, body, next, (op, fn) :: allOperations)
+        case (opArgs @ (_, select :: Nil)) :: next        => disassembleTree(newPath, select, next, opArgs :: allOperations)
+        case (opArgs @ (_, Nil)) :: next                  => disassembleTree(newPath, q"", next, opArgs :: allOperations)
+        case t :: Nil                                     => DisassembledTree(newPath, t :: allOperations)
+        case Nil                                          => DisassembledTree(newPath, allOperations)
+      }
+    }
+    disassembleTree("", tree, Nil, Nil)
   }
 }

--- a/src/core/QueryBuilderMacros.scala
+++ b/src/core/QueryBuilderMacros.scala
@@ -6,14 +6,21 @@ import scala.reflect.macros._
 class QueryBuilderMacros(val c: blackbox.Context) {
   import c.universe._
   private val self = c.prefix
-  private val selectLikeOperators = Set(
-    "isEmpty", "isDefined",
-    "last", "lastOption", "head", "headOption", "init", "tail", "get",
-    "toString")
+  private val selectLikeOperators = Set("isEmpty",
+                                        "isDefined",
+                                        "last",
+                                        "lastOption",
+                                        "head",
+                                        "headOption",
+                                        "init",
+                                        "tail",
+                                        "get",
+                                        "toString")
 
   def whereImpl[T: c.WeakTypeTag](pred: c.Expr[T => Boolean]): c.universe.Tree = {
-    val filter    = q"_root_.com.google.cloud.datastore.StructuredQuery.PropertyFilter"
-    val composite = q"_root_.com.google.cloud.datastore.StructuredQuery.CompositeFilter.and"
+    val filter = q"_root_.com.google.cloud.datastore.StructuredQuery.PropertyFilter"
+    val composite =
+      q"_root_.com.google.cloud.datastore.StructuredQuery.CompositeFilter.and"
     val predicates = pred match {
       case Expr(q"(..$_) => $body") => body
     }
@@ -21,7 +28,9 @@ class QueryBuilderMacros(val c: blackbox.Context) {
     @scala.annotation.tailrec
     def splitFilterCriteria(tree: c.Tree, resolved: List[c.Tree] = Nil): List[c.Tree] = {
       tree match {
-        case q"$_ || $_" => c.abort(c.enclosingPosition, s"Google Query Language does not support OR operator: ${show(tree)}")
+        case q"$_ || $_" =>
+          c.abort(c.enclosingPosition,
+                  s"Google Query Language does not support OR operator: ${show(tree)}")
         case q"$head && $last" =>
           splitFilterCriteria(head.asInstanceOf[c.Tree], last :: resolved)
         case q"$head" => head :: resolved
@@ -31,37 +40,59 @@ class QueryBuilderMacros(val c: blackbox.Context) {
     def buildQueryCondition(condition: c.Tree): c.Tree = {
       val DisassembledTree(path, operations) = disassembleSelectTree(condition)
       val operationsMapping: PartialFunction[c.TermName, List[c.Tree] => c.Tree] = {
-        case TermName("$eq$eq")      => args => q"$filter.eq($path, ${args.head})"
-        case TermName("$less")       => args => q"$filter.lt($path, ${args.head})"
-        case TermName("$less$eq")    => args => q"$filter.le($path, ${args.head})"
-        case TermName("$greater")    => args => q"$filter.gt($path, ${args.head})"
-        case TermName("$greater$eq") => args => q"$filter.ge($path, ${args.head})"
-        case TermName("isEmpty")     => _    => q"$filter.isNull($path)"
+        case TermName("$eq$eq") =>
+          args =>
+            q"$filter.eq($path, ${args.head})"
+        case TermName("$less") =>
+          args =>
+            q"$filter.lt($path, ${args.head})"
+        case TermName("$less$eq") =>
+          args =>
+            q"$filter.le($path, ${args.head})"
+        case TermName("$greater") =>
+          args =>
+            q"$filter.gt($path, ${args.head})"
+        case TermName("$greater$eq") =>
+          args =>
+            q"$filter.ge($path, ${args.head})"
+        case TermName("isEmpty") =>
+          _ =>
+            q"$filter.isNull($path)"
 
         case TermName("isDefined") | TermName("nonEmpty") =>
-          _ => q"$filter.gt($path, _root_.com.google.cloud.datastore.NullValue.of())"
+          _ =>
+            q"$filter.gt($path, _root_.com.google.cloud.datastore.NullValue.of())"
         case TermName("contains") | TermName("foreach") =>
-          args => q"$filter.eq($path, ${args.head})"
+          args =>
+            q"$filter.eq($path, ${args.head})"
       }
 
-      operations.collectFirst{
-        case (op, arg) if operationsMapping.isDefinedAt(op) =>
-          operationsMapping(op)(arg)
-      }.getOrElse(c.abort(c.enclosingPosition, s"Not found matching operation mapping for any of ${operations.map(_._1)}"))
+      operations
+        .collectFirst {
+          case (op, arg) if operationsMapping.isDefinedAt(op) =>
+            operationsMapping(op)(arg)
+        }
+        .getOrElse(
+          c.abort(
+            c.enclosingPosition,
+            s"Not found matching operation mapping for any of ${operations.map(_._1)}"
+          )
+        )
     }
 
-    val query = splitFilterCriteria(predicates)
-      .map(buildQueryCondition) match {
-      case Nil => c.abort(c.enclosingPosition, "Generated empty query, aborting")
+    val query = splitFilterCriteria(predicates).map(buildQueryCondition) match {
+      case Nil                    => c.abort(c.enclosingPosition, "Generated empty query, aborting")
       case singleCondition :: Nil => singleCondition
-      case multipleConditions =>       q"$composite(..$multipleConditions)"
+      case multipleConditions     => q"$composite(..$multipleConditions)"
     }
     q"$self.withFilterCriteria($query)"
   }
 
-  def sortByImpl[T: c.WeakTypeTag](pred: c.Tree*)(orderDirection: c.Tree): c.universe.Tree = {
+  def sortByImpl[T: c.WeakTypeTag](
+    pred: c.Tree*
+  )(orderDirection: c.Tree): c.universe.Tree = {
     val sortBy: Seq[c.universe.Literal] = pred
-      .collect{
+      .collect {
         case q"(..$_) => $body" => disassembleSelectTree(body)
       }
       .map(_.pathLiteral)
@@ -80,62 +111,69 @@ class QueryBuilderMacros(val c: blackbox.Context) {
 
   def orderByImpl[T: c.WeakTypeTag](pred: c.Tree*): c.universe.Tree = {
     val conditions = pred.collect {
-      case q"(..$_) => $_.asc((..$_) => $select)" =>   true -> disassembleSelectTree(select)
-      case q"(..$_) => $_.desc((..$_) => $select)" =>  false -> disassembleSelectTree(select)
+      case q"(..$_) => $_.asc((..$_) => $select)" => true -> disassembleSelectTree(select)
+      case q"(..$_) => $_.desc((..$_) => $select)" =>
+        false -> disassembleSelectTree(select)
     }
 
-    val sortBy = conditions.map { case (isAscending, dt) =>
-      if (isAscending) {
-        q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc(${dt.pathLiteral})"
-      } else {
-        q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc(${dt.pathLiteral})"
-      }
+    val sortBy = conditions.map {
+      case (isAscending, dt) =>
+        if (isAscending) {
+          q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc(${dt.pathLiteral})"
+        } else {
+          q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc(${dt.pathLiteral})"
+        }
     }
     q"$self.withSortCriteria(..$sortBy)"
   }
 
   type OpArgs = (c.TermName, List[c.Tree])
-  private case class DisassembledTree(path: String, operations: List[OpArgs]){
+  private case class DisassembledTree(path: String, operations: List[OpArgs]) {
     val pathLiteral: c.universe.Literal = Literal(Constant(path))
   }
 
   private def disassembleSelectTree(tree: c.Tree): DisassembledTree = {
     @tailrec
-    def dissembleSelectTree(
-        tree: c.Tree,
-        selects: List[c.TermName] = Nil,
-        applies: List[OpArgs] = Nil): (String, List[OpArgs]) = {
+    def dissembleSelectTree(tree: c.Tree,
+                            selects: List[c.TermName] = Nil,
+                            applies: List[OpArgs] = Nil): (String, List[OpArgs]) = {
       def isSubpath(op: String): Boolean = {
         selectLikeOperators.contains(op) || op.headOption.exists(_.isUpper)
       }
 
       tree match {
-        case q"$select.${operator}[$_](..$args)"         => dissembleSelectTree(select, selects, (operator, args) :: applies)
-        case q"$select.${operator}(..$args)"             => dissembleSelectTree(select, selects, (operator, args) :: applies)
-        case q"$select.${TermName(op)}" if isSubpath(op) => dissembleSelectTree(select, selects, (TermName(op), Nil) :: applies)
-        case q"$select.${operator}"                      => dissembleSelectTree(select, operator :: selects, applies)
-        case _                                           => selects.collect{case TermName(name) => name}.mkString(".") -> applies
+        case q"$select.${operator}[$_](..$args)" =>
+          dissembleSelectTree(select, selects, (operator, args) :: applies)
+        case q"$select.${operator}(..$args)" =>
+          dissembleSelectTree(select, selects, (operator, args) :: applies)
+        case q"$select.${TermName(op)}" if isSubpath(op) =>
+          dissembleSelectTree(select, selects, (TermName(op), Nil) :: applies)
+        case q"$select.${operator}" =>
+          dissembleSelectTree(select, operator :: selects, applies)
+        case _ => selects.collect { case TermName(name) => name }.mkString(".") -> applies
       }
     }
 
     @tailrec
-    def disassembleTree(
-          path: String,
-          tree: c.Tree,
-          nextOperations: List[OpArgs],
-          allOperations: List[OpArgs]): DisassembledTree = {
+    def disassembleTree(path: String,
+                        tree: c.Tree,
+                        nextOperations: List[OpArgs],
+                        allOperations: List[OpArgs]): DisassembledTree = {
       val (subPath, innerOperation) = dissembleSelectTree(tree)
       val newPath = (path, subPath) match {
-        case (path, "") => path
-        case ("", subPath) => subPath
+        case (path, "")      => path
+        case ("", subPath)   => subPath
         case (path, subPath) => s"$path.$subPath"
       }
       (innerOperation ++ nextOperations) match {
-        case (op, fn @ q"(..$_) => $body" :: Nil) :: next => disassembleTree(newPath, body, next, (op, fn) :: allOperations)
-        case (opArgs @ (_, select :: Nil)) :: next        => disassembleTree(newPath, select, next, opArgs :: allOperations)
-        case (opArgs @ (_, Nil)) :: next                  => disassembleTree(newPath, q"", next, opArgs :: allOperations)
-        case t :: Nil                                     => DisassembledTree(newPath, t :: allOperations)
-        case Nil                                          => DisassembledTree(newPath, allOperations)
+        case (op, fn @ q"(..$_) => $body" :: Nil) :: next =>
+          disassembleTree(newPath, body, next, (op, fn) :: allOperations)
+        case (opArgs @ (_, select :: Nil)) :: next =>
+          disassembleTree(newPath, select, next, opArgs :: allOperations)
+        case (opArgs @ (_, Nil)) :: next =>
+          disassembleTree(newPath, q"", next, opArgs :: allOperations)
+        case t :: Nil => DisassembledTree(newPath, t :: allOperations)
+        case Nil      => DisassembledTree(newPath, allOperations)
       }
     }
     disassembleTree("", tree, Nil, Nil)

--- a/src/core/QueryBuilderMacros.scala
+++ b/src/core/QueryBuilderMacros.scala
@@ -1,0 +1,99 @@
+package mutatus
+
+import scala.reflect.macros._
+
+object QueryBuilderMacros {
+  def whereImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Expr[T => Boolean]): c.universe.Tree = {
+    import c.universe._
+    val self = c.prefix
+    val predicates = pred match {
+      case Expr(q"(..$_) => $body") => body
+    }
+
+    @scala.annotation.tailrec
+    def resolveConditions(tree: c.Tree, resolved: List[c.Tree] = Nil): List[c.Tree] = {
+      tree match {
+        case q"$_ || $_" => c.abort(c.enclosingPosition, s"Google Query Language does not support OR operator: ${show(tree)}")
+        case q"$head && $last" =>
+          resolveConditions(head.asInstanceOf[c.Tree], last :: resolved)
+        case q"$head" => head :: resolved
+      }
+    }
+
+    val filter    = q"_root_.com.google.cloud.datastore.StructuredQuery.PropertyFilter"
+    val composite = q"_root_.com.google.cloud.datastore.StructuredQuery.CompositeFilter.and"
+    val queries: List[c.Tree] = resolveConditions(predicates.asInstanceOf[c.Tree])
+      .map {
+        case q"$_.${field}.${operator}[$_](..$args)" => (field, operator, args)
+        case q"$_.${field}.${operator}(..$args)" => (field, operator, args)
+        case q"$_.${field}.${operator}" => (field, operator, Nil)
+      }.map {
+      case (field, operator, args) =>
+        val fieldName = field match {
+          case TermName(fieldName) => Literal(Constant(fieldName))
+        }
+
+        operator match {
+          case TermName("$eq$eq") => q"$filter.eq($fieldName, ${args.head})"
+          case TermName("$less") => q"$filter.lt($fieldName, ${args.head})"
+          case TermName("$less$eq") => q"$filter.le($fieldName, ${args.head})"
+          case TermName("$greater") => q"$filter.gt($fieldName, ${args.head})"
+          case TermName("$greater$eq") => q"$filter.ge($fieldName, ${args.head})"
+          case TermName("isEmpty") => q"$filter.isNull($fieldName)"
+          case TermName("contains") => q"$filter.eq($fieldName, ${args.head})"
+          case other =>
+            c.abort(c.enclosingPosition, s"Not defined handling for operator $other and args $args")
+        }
+    }
+
+    val query = if (queries.size > 1) {
+      q"$composite(..$queries)"
+    } else {
+      queries.head
+    }
+    q"$self.withFilterCriteria($query)"
+  }
+
+  def sortByImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Tree*)(orderDirection: c.Tree): c.universe.Tree = {
+    import c.universe._
+    val self = c.prefix
+    val sortBy: Seq[Literal] = pred.collect {
+      case q"(..$_) => $_.${field}" =>
+        field match {
+          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
+            fieldLiteral
+        }
+    }
+
+    q""" {
+         val isAscending = $orderDirection == _root_.mutatus.OrderDirection.Ascending
+         val sortBy: List[StructuredQuery.OrderBy] = if(isAscending){
+            List(..$sortBy).map(_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc(_))
+          }else{
+            List(..$sortBy).map(_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc(_))
+          }
+
+        $self.withSortCriteria(sortBy:_*)
+        }
+       """
+  }
+  
+  def orderByImpl[T: c.WeakTypeTag](c: blackbox.Context)(pred: c.Tree*): c.universe.Tree = {
+    import c.universe._
+
+    val self = c.prefix
+    val sortBy: Seq[c.Tree] = pred.collect {
+      case q"(..$_) => $_.asc((..$_) => $_.${field})" =>
+        field match {
+          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
+            q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.asc($fieldLiteral)"
+        }
+      case q"(..$_) => $_.desc((..$_) => $_.${field})" =>
+        field match {
+          case TermName(fieldname) => val fieldLiteral = Literal(Constant(fieldname))
+            q"_root_.com.google.cloud.datastore.StructuredQuery.OrderBy.desc($fieldLiteral)"
+        }
+    }
+    q"$self.withSortCriteria(..$sortBy)"
+  }
+}

--- a/src/core/mutatus.scala
+++ b/src/core/mutatus.scala
@@ -46,8 +46,6 @@ object `package` {
       svc.readWrite.delete(idField.idKey(idField.key(value)).newKey(dao.keyFactory))
   }
 
-  
-
   private[mutatus] def ifEmpty[T](str: String, empty: T, nonEmpty: String => T): T =
     if(str.isEmpty) empty else nonEmpty(str)
 }


### PR DESCRIPTION
Basic implementation for queries, allowing to build them using syntax: #7 
```scala
    val results: Iterator[QueringTestEntity] = Dao[QueringTestEntity]
      .query
      .where(_.listParam.contains("big"))
      .where(x => x.intParam == 0 && x.optionalParam.isEmpty)
      .sortBy(_.intParam, _.stringParam)  // takes implicit Order - Ascending/Descending order is applies to all fields
      .orderBy(_.asc(_.intParam), _.desc(_.stringParam)) // more granulated style for providing sorting order
      .limit(100, 10)
      .find()
```
