### PR TITLE
Feature/15 change query syntax

### DIFF
--- a/.fury.conf
+++ b/.fury.conf
@@ -7,7 +7,7 @@
 #
 # For more information, please visit https://propensive.com/fury/
 #
-layerRef	QmejKBVzef1Kayyr16yhKzC8pSz87Xyyox1JqVyrp2hQJY
+layerRef	Qmdyx5CQ1EvxagyGMyceJoEv2MPR2c4oZnwEFaJioT1pBv
 published	Some	url	fury://furore.dev/propensive/mutatus
 		version	1.2
 		layerRef	QmRar2rRKjXexCYAsuBB2ngNr6nr1esPuMfcFdfn7anNFz

--- a/src/core/QueryBuilder.scala
+++ b/src/core/QueryBuilder.scala
@@ -51,9 +51,11 @@ case class QueryBuilder[T] private[mutatus] (
   }
   def take(n: Int): QueryBuilder[T] = copy[T](limit = Some(n))
   def drop(n: Int): QueryBuilder[T] = copy[T](offset = Some(n))
+  def slice(offset: Int, limit: Int) =
+    copy[T](offset = Some(offset), limit = Some(limit))
 
   /** Materializes query and returns Stream of entities for GCP Storage */
-  def apply()(
+  def run()(
       implicit svc: Service = Service.default,
       namespace: Namespace,
       decoder: Decoder[T]
@@ -77,10 +79,4 @@ case class QueryBuilder[T] private[mutatus] (
       def hasNext: Boolean = results.hasNext
     }.map(decoder.decode(_)).toStream
   }
-
-  def run()(
-      implicit svc: Service = Service.default,
-      namespace: Namespace,
-      decoder: Decoder[T]
-  ): Stream[T] = apply()
 }

--- a/src/core/mutatus.scala
+++ b/src/core/mutatus.scala
@@ -158,21 +158,6 @@ object Service {
   implicit val default: Service = Service(
     DatastoreOptions.getDefaultInstance.getService
   )
-
-  object noop {
-
-    /** Service instance which does not connect to any GCP Datastore, designed to be used in tests */
-    implicit val noopService: Service = Service {
-      import com.google.cloud.NoCredentials
-      DatastoreOptions
-        .newBuilder()
-        .setProjectId("noop")
-        .setCredentials(NoCredentials.getInstance())
-        .setHost("localhost")
-        .build()
-        .getService
-    }
-  }
 }
 
 /** typeclass for encoding a value into a type which can be stored in the GCP Datastore */
@@ -202,7 +187,6 @@ abstract class IdField[-T] {
 }
 
 object IdField {
-
   type FindMetadataAux[T, R] = FindMetadata[id, T] { type Return = R }
 
   implicit def annotationId[T, R](implicit ann: FindMetadata[id, T] {

--- a/src/tests/EndToEndSpec.scala
+++ b/src/tests/EndToEndSpec.scala
@@ -110,10 +110,10 @@ case class EndToEndSpec()(implicit runner: Runner) {
   }
 
   test("fetch entities - simple")(
-    Dao[TestSimpleEntity].all.run.toVector.sortBy(_.id)
+    Dao[TestSimpleEntity].all.run().toVector.sortBy(_.id)
   ).assert(_ == (simpleEntities ++ batchedSimpleEntities).sortBy(_.id))
   test("fetch entities - complex - long id")(
-    Dao[TestComplexLongId].all.run.toVector.sortBy(_.id)
+    Dao[TestComplexLongId].all.run().toVector.sortBy(_.id)
   ).assert(_ == longIdComplexEntities.sortBy(_.id))
 
   simpleEntities.take(3).foreach { e =>
@@ -206,7 +206,7 @@ case class EndToEndSpec()(implicit runner: Runner) {
 
   test("removes entities in batch mode") {
     batchedSimpleEntities.deleteAll()
-    Dao[TestSimpleEntity].all.run
+    Dao[TestSimpleEntity].all.run()
   }.assert(_.isEmpty)
 
   test("removed everything") {

--- a/src/tests/EndToEndSpec.scala
+++ b/src/tests/EndToEndSpec.scala
@@ -109,12 +109,12 @@ case class EndToEndSpec()(implicit runner: Runner) {
       }
   }
 
-  // test("fetch entities - simple")(
-  //   Dao[TestSimpleEntity].all().toVector.sortBy(_.id)
-  // ).assert(_ == (simpleEntities ++ batchedSimpleEntities).sortBy(_.id))
-  // test("fetch entities - complex - long id")(
-  //   Dao[TestComplexLongId].all().toVector.sortBy(_.id)
-  // ).assert(_ == longIdComplexEntities.sortBy(_.id))
+  test("fetch entities - simple")(
+    Dao[TestSimpleEntity].all.run.toVector.sortBy(_.id)
+  ).assert(_ == (simpleEntities ++ batchedSimpleEntities).sortBy(_.id))
+  test("fetch entities - complex - long id")(
+    Dao[TestComplexLongId].all.run.toVector.sortBy(_.id)
+  ).assert(_ == longIdComplexEntities.sortBy(_.id))
 
   simpleEntities.take(3).foreach { e =>
     test("fetch entity by id - simple")(Dao[TestSimpleEntity].unapply(e.id))
@@ -206,14 +206,14 @@ case class EndToEndSpec()(implicit runner: Runner) {
 
   test("removes entities in batch mode") {
     batchedSimpleEntities.deleteAll()
-    Dao[TestSimpleEntity].all()
+    Dao[TestSimpleEntity].all.run
   }.assert(_.isEmpty)
 
   test("removed everything") {
-    Dao[TestSimpleEntity].all() ++
-      Dao[TestComplexLongId].all() ++
-      Dao[TestComplexStringId].all() ++
-      Dao[TestComplexGuid].all()
+    Dao[TestSimpleEntity].all.run() ++
+      Dao[TestComplexLongId].all.run() ++
+      Dao[TestComplexStringId].all.run() ++
+      Dao[TestComplexGuid].all.run()
   }.assert(_.isEmpty)
 
 }

--- a/src/tests/EndToEndSpec.scala
+++ b/src/tests/EndToEndSpec.scala
@@ -109,12 +109,12 @@ case class EndToEndSpec()(implicit runner: Runner) {
       }
   }
 
-  test("fetch entities - simple")(
-    Dao[TestSimpleEntity].all().toVector.sortBy(_.id)
-  ).assert(_ == (simpleEntities ++ batchedSimpleEntities).sortBy(_.id))
-  test("fetch entities - complex - long id")(
-    Dao[TestComplexLongId].all().toVector.sortBy(_.id)
-  ).assert(_ == longIdComplexEntities.sortBy(_.id))
+  // test("fetch entities - simple")(
+  //   Dao[TestSimpleEntity].all().toVector.sortBy(_.id)
+  // ).assert(_ == (simpleEntities ++ batchedSimpleEntities).sortBy(_.id))
+  // test("fetch entities - complex - long id")(
+  //   Dao[TestComplexLongId].all().toVector.sortBy(_.id)
+  // ).assert(_ == longIdComplexEntities.sortBy(_.id))
 
   simpleEntities.take(3).foreach { e =>
     test("fetch entity by id - simple")(Dao[TestSimpleEntity].unapply(e.id))
@@ -143,13 +143,14 @@ case class EndToEndSpec()(implicit runner: Runner) {
     )
 
   test("allows to fetch using queries") {
-    Dao[TestComplexLongId].query
-      .where(x =>
-        x.innerOpt.exists(_.int >= 2) && x.innerOpt.exists(_.int <= 8)
-      )
-      .orderBy(_.desc(_.innerOpt.map(_.int)))
-      .limit(limit = 2, offset = 1)
-      .find()
+    Dao[TestComplexLongId].all
+      .filter(_.innerOpt.exists(_.int >= 2))
+      .filter(_.innerOpt.exists(_.int <= 8))
+      .sortBy(_.innerOpt.map(_.int))
+      .reverse
+      .drop(1)
+      .take(2)
+      .run()
       .toList
   }.assert(
     _ == longIdComplexEntities
@@ -209,7 +210,7 @@ case class EndToEndSpec()(implicit runner: Runner) {
   }.assert(_.isEmpty)
 
   test("removed everything") {
-    Dao[TestSimpleEntity].all ++
+    Dao[TestSimpleEntity].all() ++
       Dao[TestComplexLongId].all() ++
       Dao[TestComplexStringId].all() ++
       Dao[TestComplexGuid].all()

--- a/src/tests/QueryBuilderSpec.scala
+++ b/src/tests/QueryBuilderSpec.scala
@@ -5,11 +5,22 @@ import com.google.cloud.datastore.StructuredQuery._
 import com.google.cloud.datastore._
 import mutatus._
 import probably._
-import Service.noop._
 
 case class QueryBuilderSpec()(implicit runner: Runner) {
   import QueryBuilderSpec.Model._
   lazy val builder = Dao[QueringTestEntity].all
+
+  /** Service instance which does not connect to any GCP Datastore*/
+  implicit val noopService: Service = Service {
+    import com.google.cloud.NoCredentials
+    DatastoreOptions
+      .newBuilder()
+      .setProjectId("noop")
+      .setCredentials(NoCredentials.getInstance())
+      .setHost("localhost")
+      .build()
+      .getService
+  }
 
   List(
     builder.filter(_.intParam == 0) -> PropertyFilter.eq("intParam", 0),

--- a/src/tests/QueryBuilderSpec.scala
+++ b/src/tests/QueryBuilderSpec.scala
@@ -5,10 +5,10 @@ import com.google.cloud.datastore.StructuredQuery._
 import com.google.cloud.datastore._
 import mutatus._
 import probably._
+import Service.noop._
 
 case class QueryBuilderSpec()(implicit runner: Runner) {
   import QueryBuilderSpec.Model._
-  implicit val service = Service.noop
   lazy val builder = Dao[QueringTestEntity].all
 
   List(


### PR DESCRIPTION
Resolves #15 

Changed query syntax according to discussion at issue, e.q

```
Dao[T].all[.filter(...)*][.sortBy(...)][.reverse][.take(...)]()
```

1. Defined alias `query`  for `all`. Both of them creates new query builder. 
2. Query is materialized when using `apply` / `()` or defined alias `run`
1. Changed method of passing `implicit service: Service`. Current implementation did not allow to pass custom `Service` instance, e.q in tests. Also defined `default` and `noop` (mock) `Service` instances inside it's companion object
3. Query now returns `Stream[T]` instead of `Iterator[T]`. Such change allows to use new syntax as follows, where each case produces the same results

- `Dao[Type].all.filter(x).sortBy(y).reverse.sortBy(z).run()`
- `Dao[Type].all.filter(x).sortBy(y).reverse.run().sortBy(z)`
- `Dao[Type].all.filter(x).sortBy(y).run().reverse.sortBy(z)`
- `Dao[Type].all.filter(x).run().sortBy(y).reverse.sortBy(z)`
- `Dao[Type].all.run().filter(x).sortBy(y).reverse.sortBy(z)`


**Not applies changes:** 
1. Not renamed `Dao` to `Query`, as it allows for other operations, that is`unapply` allows fetching entity by Id and as `Dao` contains keyFactory